### PR TITLE
Add googlejavaformat-action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,6 +1,6 @@
 name: Format
 
-on: [ push, pull_request ]
+on: [ pull_request ]
 
 jobs:
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,17 +1,13 @@
 name: Format
 
-on:
-  push:
-    branches:
-      - master
+on: [ push, pull_request ]
 
 jobs:
 
-  formatting:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2 # v2 minimum required
-      - uses: axel-op/googlejavaformat-action@v3
-        with:
-          args: "--skip-sorting-imports --aosp --replace"
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
+    formatting:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v2 # v2 minimum required
+            -   uses: axel-op/googlejavaformat-action@v3
+                with:
+                    args: "--set-exit-if-changed --aosp --skip-sorting-imports --skip-javadoc-formatting"

--- a/.idea/google-java-format.xml
+++ b/.idea/google-java-format.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-    <component name="GoogleJavaFormatSettings">
-        <option name="enabled" value="true"/>
-        <option name="style" value="AOSP"/>
-    </component>
-</project>

--- a/.idea/google-java-format.xml
+++ b/.idea/google-java-format.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+    <component name="GoogleJavaFormatSettings">
+        <option name="enabled" value="true"/>
+        <option name="style" value="AOSP"/>
+    </component>
+</project>


### PR DESCRIPTION
Fixes #59 

Nicht formatierte .java-Dateien bekommen keinen grünen Punkt.

Erfordert in IntelliJ das google-java-format Plugin.