### PR TITLE
Text auf HUD zeichnen

### DIFF
--- a/code/build.gradle
+++ b/code/build.gradle
@@ -54,6 +54,7 @@ project(":desktop") {
 //        api "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-desktop"
 //        api "com.badlogicgames.gdx:gdx-tools:$gdxVersion"
 //        api "com.badlogicgames.gdx-controllers:gdx-controllers-desktop:$gdxControllersVersion"
+        api "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-desktop"
     }
 }
 
@@ -67,7 +68,7 @@ project(":core") {
 //        api "com.badlogicgames.gdx-controllers:gdx-controllers-core:$gdxControllersVersion"
 //        api "com.badlogicgames.box2dlights:box2dlights:$box2DLightsVersion"
 //        api "com.badlogicgames.gdx:gdx-ai:$aiVersion"
-
+        api "com.badlogicgames.gdx:gdx-freetype:$gdxVersion"
         // JUnit 4, Mockito and Powermock for testing:
 
         // https://mvnrepository.com/artifact/junit/junit

--- a/code/core/src/controller/HUDController.java
+++ b/code/core/src/controller/HUDController.java
@@ -1,12 +1,19 @@
 package controller;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.utils.viewport.ScreenViewport;
 import graphic.HUDCamera;
 import interfaces.IHUDElement;
 
 public class HUDController extends AbstractController<IHUDElement> {
     private final HUDCamera hudCamera;
     private final SpriteBatch batch;
+    private Stage textStage;
 
     /**
      * Keeps a set of HUD elements and makes sure they are drawn.
@@ -16,6 +23,7 @@ public class HUDController extends AbstractController<IHUDElement> {
     public HUDController(SpriteBatch batch, HUDCamera camera) {
         this.batch = batch;
         hudCamera = camera;
+        textStage = new Stage(new ScreenViewport(), batch);
         hudCamera.getPosition().set(0, 0, 0);
         hudCamera.update();
     }
@@ -26,5 +34,73 @@ public class HUDController extends AbstractController<IHUDElement> {
         hudCamera.update();
         batch.setProjectionMatrix(hudCamera.combined);
         forEach(element -> element.draw(batch));
+        textStage.act();
+        textStage.draw();
+    }
+
+    /**
+     * Draws a given text on the screen.
+     *
+     * @param text text to draw
+     * @param fontPath font to use
+     * @param color color to use
+     * @param size font size to use
+     * @param width width of the text box
+     * @param height height of the text box
+     * @param x x-position in pixel
+     * @param y y-position in pixel
+     * @param borderWidth borderWidth for the text
+     * @return Label (use this to alter text or remove the text later)
+     */
+    public Label drawText(
+            String text,
+            String fontPath,
+            Color color,
+            int size,
+            int width,
+            int height,
+            int x,
+            int y,
+            int borderWidth) {
+        FreeTypeFontGenerator generator = new FreeTypeFontGenerator(Gdx.files.internal(fontPath));
+        FreeTypeFontGenerator.FreeTypeFontParameter parameter =
+                new FreeTypeFontGenerator.FreeTypeFontParameter();
+        parameter.size = size;
+        parameter.borderWidth = borderWidth;
+        parameter.color = color;
+        Label.LabelStyle labelStyle = new Label.LabelStyle();
+        labelStyle.font = generator.generateFont(parameter);
+        generator.dispose();
+        Label label = new Label(text, labelStyle);
+        label.setSize(width, height);
+        label.setPosition(x, y);
+
+        textStage.addActor(label);
+        return label;
+    }
+
+    /**
+     * Draws a given text on the screen.
+     *
+     * @param text text to draw
+     * @param fontPath font to use
+     * @param color color to use
+     * @param size font size to use
+     * @param width width of the text box
+     * @param height height of the text box
+     * @param x x-position in pixel
+     * @param y y-position in pixel
+     * @return Label (use this to alter text or remove the text later)
+     */
+    public Label drawText(
+            String text,
+            String fontPath,
+            Color color,
+            int size,
+            int width,
+            int height,
+            int x,
+            int y) {
+        return drawText(text, fontPath, color, size, width, height, x, y, 1);
     }
 }

--- a/code/core/test/controller/HUDControllerTest.java
+++ b/code/core/test/controller/HUDControllerTest.java
@@ -2,12 +2,14 @@ package controller;
 
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.Vector3;
+import com.badlogic.gdx.scenes.scene2d.Stage;
 import graphic.HUDCamera;
 import interfaces.IHUDElement;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -22,14 +24,16 @@ public class HUDControllerTest {
     private IHUDElement element1;
     private IHUDElement element2;
     private HUDController controller;
+    private Stage textStage;
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
         batch = Mockito.mock(SpriteBatch.class);
         camera = Mockito.mock(HUDCamera.class);
         element1 = Mockito.mock(IHUDElement.class);
         element2 = Mockito.mock(IHUDElement.class);
-
+        textStage = Mockito.mock(Stage.class);
+        PowerMockito.whenNew(Stage.class).withAnyArguments().thenReturn(textStage);
         Vector3 vector3toReturn = new Vector3();
         when(camera.getPosition()).thenReturn(vector3toReturn);
 
@@ -49,7 +53,9 @@ public class HUDControllerTest {
         verify(batch).setProjectionMatrix(camera.combined);
         verify(element1).draw(batch);
         verify(element2).draw(batch);
-        verifyNoMoreInteractions(camera, batch, element1, element2);
+        verify(textStage).act();
+        verify(textStage).draw();
+        verifyNoMoreInteractions(camera, batch, element1, element2, textStage);
     }
 
     @Test
@@ -62,6 +68,8 @@ public class HUDControllerTest {
         verify(camera, atLeastOnce()).update();
         // verify update method logic:
         verify(batch).setProjectionMatrix(camera.combined);
-        verifyNoMoreInteractions(camera, batch, element1, element2);
+        verify(textStage).act();
+        verify(textStage).draw();
+        verifyNoMoreInteractions(camera, batch, element1, element2, textStage);
     }
 }

--- a/code/core/test/graphic/PainterTest.java
+++ b/code/core/test/graphic/PainterTest.java
@@ -29,7 +29,6 @@ public class PainterTest {
         batch = Mockito.mock(SpriteBatch.class);
         painter = Mockito.spy(new Painter(cam));
         frustum = Mockito.mock(Frustum.class);
-
         Mockito.when(cam.getFrustum()).thenReturn(frustum);
         Mockito.when(frustum.pointInFrustum(anyFloat(), anyFloat(), anyFloat())).thenReturn(true);
     }


### PR DESCRIPTION
Fixes #70

Funktionsweise ist ähnlich zum alten Dungeon.
`textStage` kann `labels` halten und kümmert sich darum, dass diese gezeichnet werden etc.
Quasi ein eigener kleiner Controller für Texte. Unser `HUDController` kümmert sich dann darum, dass `textStage` auch zeichnet wenn es an der Zeit ist.

Theoretisch könnte man einen eigenen Controller für den Text-Stuff bauen, es wird dadurch aber nicht grade übersichtlicher und ich halte eine zentrale Anlaufstelle für alle HUD-Geschichten für die beste Lösung. 