### PR TITLE
onLevelLoad with reflection

### DIFF
--- a/code/core/src/controller/MainController.java
+++ b/code/core/src/controller/MainController.java
@@ -12,7 +12,6 @@ import level.generator.dummy.DummyGenerator;
 import level.generator.dungeong.levelg.LevelG;
 import tools.Constants;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import static com.badlogic.gdx.graphics.GL20.GL_COLOR_BUFFER_BIT;
@@ -50,13 +49,7 @@ public class MainController extends ScreenAdapter {
     @Override
     public final void render(float delta) {
         if (doFirstFrame) {
-            try {
-                firstFrame();
-            } catch (InvocationTargetException e) {
-                e.printStackTrace();
-            } catch (IllegalAccessException e) {
-                e.printStackTrace();
-            }
+            firstFrame();
         }
 
         // clears the screen
@@ -72,7 +65,7 @@ public class MainController extends ScreenAdapter {
         endFrame();
     }
 
-    private void firstFrame() throws InvocationTargetException, IllegalAccessException {
+    private void firstFrame() {
         doFirstFrame = false;
         entityController = new EntityController();
         setupCamera();

--- a/code/core/src/controller/MainController.java
+++ b/code/core/src/controller/MainController.java
@@ -32,7 +32,7 @@ public class MainController extends ScreenAdapter {
     private boolean doFirstFrame = true;
 
     // --------------------------- OWN IMPLEMENTATION ---------------------------
-    protected void setup() throws InvocationTargetException, IllegalAccessException {}
+    protected void setup() {}
 
     protected void beginFrame() {}
 
@@ -50,7 +50,13 @@ public class MainController extends ScreenAdapter {
     @Override
     public final void render(float delta) {
         if (doFirstFrame) {
-            firstFrame();
+            try {
+                firstFrame();
+            } catch (InvocationTargetException e) {
+                e.printStackTrace();
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
         }
 
         // clears the screen
@@ -66,7 +72,7 @@ public class MainController extends ScreenAdapter {
         endFrame();
     }
 
-    private void firstFrame() {
+    private void firstFrame() throws InvocationTargetException, IllegalAccessException {
         doFirstFrame = false;
         entityController = new EntityController();
         setupCamera();

--- a/code/core/src/controller/MainController.java
+++ b/code/core/src/controller/MainController.java
@@ -12,6 +12,9 @@ import level.generator.dummy.DummyGenerator;
 import level.generator.dungeong.levelg.LevelG;
 import tools.Constants;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import static com.badlogic.gdx.graphics.GL20.GL_COLOR_BUFFER_BIT;
 
 /** The heart of the framework. From here all strings are pulled. */
@@ -29,7 +32,7 @@ public class MainController extends ScreenAdapter {
     private boolean doFirstFrame = true;
 
     // --------------------------- OWN IMPLEMENTATION ---------------------------
-    protected void setup() {}
+    protected void setup() throws InvocationTargetException, IllegalAccessException {}
 
     protected void beginFrame() {}
 
@@ -73,7 +76,7 @@ public class MainController extends ScreenAdapter {
         hud = new HUDController(hudBatch, hudCamera);
         if (Constants.USE_DUMMY_GENERATOR) generator = new DummyGenerator();
         else generator = new LevelG();
-        levelAPI = new LevelAPI(batch, painter, generator);
+        setupLevelAPI(batch, painter, generator);
         setup();
     }
 
@@ -88,5 +91,17 @@ public class MainController extends ScreenAdapter {
 
         // See also:
         // https://stackoverflow.com/questions/52011592/libgdx-set-ortho-camera
+    }
+
+    private void setupLevelAPI(SpriteBatch batch, Painter painter, IGenerator generator) {
+        try {
+            // this method will be called every time a new level gets load
+            Method functionToPass = this.getClass().getMethod("onLevelLoad");
+            // if you need parameter four your method, add them here
+            Object[] arguments = new Object[0];
+            levelAPI = new LevelAPI(batch, painter, generator, functionToPass, this, arguments);
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/code/core/src/demo/MyController.java
+++ b/code/core/src/demo/MyController.java
@@ -5,12 +5,14 @@ import com.badlogic.gdx.Input;
 import controller.MainController;
 import tools.Point;
 
+import java.lang.reflect.InvocationTargetException;
+
 public class MyController extends MainController {
 
     Point p = new Point(3, 3);
 
     @Override
-    protected void setup() {
+    protected void setup() throws InvocationTargetException, IllegalAccessException {
         camera.setFocusPoint(p);
         levelAPI.loadLevel();
     }
@@ -29,5 +31,10 @@ public class MyController extends MainController {
     @Override
     protected void endFrame() {
         camera.setFocusPoint(p);
+    }
+
+    @Override
+    protected void onLevelLoad() {
+        System.out.println("Load level");
     }
 }

--- a/code/core/src/demo/MyController.java
+++ b/code/core/src/demo/MyController.java
@@ -5,8 +5,6 @@ import com.badlogic.gdx.Input;
 import controller.MainController;
 import tools.Point;
 
-import java.lang.reflect.InvocationTargetException;
-
 public class MyController extends MainController {
 
     Point p = new Point(3, 3);
@@ -14,13 +12,7 @@ public class MyController extends MainController {
     @Override
     protected void setup() {
         camera.setFocusPoint(p);
-        try {
-            levelAPI.loadLevel();
-        } catch (InvocationTargetException e) {
-            e.printStackTrace();
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        }
+        levelAPI.loadLevel();
     }
 
     @Override

--- a/code/core/src/demo/MyController.java
+++ b/code/core/src/demo/MyController.java
@@ -12,9 +12,15 @@ public class MyController extends MainController {
     Point p = new Point(3, 3);
 
     @Override
-    protected void setup() throws InvocationTargetException, IllegalAccessException {
+    protected void setup() {
         camera.setFocusPoint(p);
-        levelAPI.loadLevel();
+        try {
+            levelAPI.loadLevel();
+        } catch (InvocationTargetException e) {
+            e.printStackTrace();
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
     }
 
     @Override

--- a/code/core/src/level/LevelAPI.java
+++ b/code/core/src/level/LevelAPI.java
@@ -7,21 +7,36 @@ import level.elements.Room;
 import level.elements.Tile;
 import level.generator.IGenerator;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 public class LevelAPI {
+    private final Method onLevelLoad;
+    private final Object klass;
+    private final Object[] args;
     private Level currentLevel;
     private SpriteBatch batch;
     private Painter painter;
     private IGenerator gen;
 
-    public LevelAPI(SpriteBatch batch, Painter painter, IGenerator gen) {
+    public LevelAPI(
+            SpriteBatch batch,
+            Painter painter,
+            IGenerator gen,
+            Method onLevelLoad,
+            Object klass,
+            Object[] args) {
         this.gen = gen;
         this.batch = batch;
         this.painter = painter;
+        this.onLevelLoad = onLevelLoad;
+        this.klass = klass;
+        this.args = args;
     }
 
-    public void loadLevel() {
+    public void loadLevel() throws InvocationTargetException, IllegalAccessException {
         currentLevel = gen.getLevel();
-        // currentLevel = createDummyLevel();
+        onLevelLoad.invoke(klass, args);
     }
 
     public void update() {

--- a/code/core/src/level/LevelAPI.java
+++ b/code/core/src/level/LevelAPI.java
@@ -34,9 +34,15 @@ public class LevelAPI {
         this.args = args;
     }
 
-    public void loadLevel() throws InvocationTargetException, IllegalAccessException {
+    public void loadLevel() {
         currentLevel = gen.getLevel();
-        onLevelLoad.invoke(klass, args);
+        try {
+            onLevelLoad.invoke(klass, args);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        } catch (InvocationTargetException e) {
+            e.printStackTrace();
+        }
     }
 
     public void update() {


### PR DESCRIPTION
Fixes #108 (vgl. mit #119) 

In dieser Variante wird Reflection genutzt, um die Methode `onLevelLoad` aufzurufen. Die Methode wird immer dann aufgerufen, wenn ein neues Level geladen wird. 
Die Methode ist im `MainController` angelegt und kann im eigenen Controller überschrieben werden. 

Pro: easy to use.
Con: reflection