### PR TITLE
onLevelLoad with a class

### DIFF
--- a/code/core/src/controller/MainController.java
+++ b/code/core/src/controller/MainController.java
@@ -35,7 +35,6 @@ public class MainController extends ScreenAdapter {
 
     protected void endFrame() {}
 
-    protected void onLevelLoad() {}
     // --------------------------- END OWN IMPLEMENTATION ------------------------
 
     /**

--- a/code/core/src/controller/OnLevelLoader.java
+++ b/code/core/src/controller/OnLevelLoader.java
@@ -1,0 +1,5 @@
+package controller;
+
+public abstract class OnLevelLoader {
+    public abstract void onLevelLoad();
+}

--- a/code/core/src/demo/MyController.java
+++ b/code/core/src/demo/MyController.java
@@ -3,6 +3,7 @@ package demo;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import controller.MainController;
+import controller.OnLevelLoader;
 import tools.Point;
 
 public class MyController extends MainController {
@@ -12,6 +13,17 @@ public class MyController extends MainController {
     @Override
     protected void setup() {
         camera.setFocusPoint(p);
+        levelAPI.setOnLevelLoader(new MyLevelLoader());
+
+        // alternative
+        levelAPI.setOnLevelLoader(
+                new OnLevelLoader() {
+                    @Override
+                    public void onLevelLoad() {
+                        System.out.println("So geht es auch.");
+                    }
+                });
+
         levelAPI.loadLevel();
     }
 

--- a/code/core/src/demo/MyLevelLoader.java
+++ b/code/core/src/demo/MyLevelLoader.java
@@ -1,0 +1,11 @@
+package demo;
+
+import controller.OnLevelLoader;
+
+public class MyLevelLoader extends OnLevelLoader {
+
+    @Override
+    public void onLevelLoad() {
+        System.out.println("OnLevelLoad");
+    }
+}

--- a/code/core/src/level/LevelAPI.java
+++ b/code/core/src/level/LevelAPI.java
@@ -1,6 +1,7 @@
 package level;
 
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import controller.OnLevelLoader;
 import graphic.Painter;
 import level.elements.Level;
 import level.elements.Room;
@@ -12,6 +13,7 @@ public class LevelAPI {
     private SpriteBatch batch;
     private Painter painter;
     private IGenerator gen;
+    private OnLevelLoader onLevelLoader;
 
     public LevelAPI(SpriteBatch batch, Painter painter, IGenerator gen) {
         this.gen = gen;
@@ -19,13 +21,23 @@ public class LevelAPI {
         this.painter = painter;
     }
 
+    public LevelAPI(
+            SpriteBatch batch, Painter painter, IGenerator gen, OnLevelLoader onLevelLoader) {
+        this(batch, painter, gen);
+        this.onLevelLoader = onLevelLoader;
+    }
+
     public void loadLevel() {
         currentLevel = gen.getLevel();
-        // currentLevel = createDummyLevel();
+        if (onLevelLoader != null) onLevelLoader.onLevelLoad();
     }
 
     public void update() {
         drawLevel();
+    }
+
+    public void setOnLevelLoader(OnLevelLoader onLevelLoader) {
+        this.onLevelLoader = onLevelLoader;
     }
 
     public Level getCurrentLevel() {


### PR DESCRIPTION
Fixes #108 (vgl. mit #118)

In dieser Variante wird eine eigene Klasse genutzt, um die Methode onLevelLoad zu implementieren. Die Methode wird immer dann aufgerufen, wenn ein neues Level geladen wird.


Pro: schöner als reflection in der Integration.
Con: umständliche Verwendung. 