### PR TITLE
onLevelLoad with interface

### DIFF
--- a/code/core/src/controller/MainController.java
+++ b/code/core/src/controller/MainController.java
@@ -36,7 +36,6 @@ public abstract class MainController extends ScreenAdapter implements IOnLevelLo
 
     protected abstract void endFrame();
 
-    public abstract void onLevelLoad();
     // --------------------------- END OWN IMPLEMENTATION ------------------------
 
     /**

--- a/code/core/src/controller/MainController.java
+++ b/code/core/src/controller/MainController.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import graphic.DungeonCamera;
 import graphic.HUDCamera;
 import graphic.Painter;
+import level.IOnLevelLoader;
 import level.LevelAPI;
 import level.generator.IGenerator;
 import level.generator.dummy.DummyGenerator;
@@ -15,7 +16,7 @@ import tools.Constants;
 import static com.badlogic.gdx.graphics.GL20.GL_COLOR_BUFFER_BIT;
 
 /** The heart of the framework. From here all strings are pulled. */
-public class MainController extends ScreenAdapter {
+public abstract class MainController extends ScreenAdapter implements IOnLevelLoader {
     protected SpriteBatch batch;
     protected SpriteBatch hudBatch;
     protected HUDCamera hudCamera;
@@ -29,13 +30,13 @@ public class MainController extends ScreenAdapter {
     private boolean doFirstFrame = true;
 
     // --------------------------- OWN IMPLEMENTATION ---------------------------
-    protected void setup() {}
+    protected abstract void setup();
 
-    protected void beginFrame() {}
+    protected abstract void beginFrame();
 
-    protected void endFrame() {}
+    protected abstract void endFrame();
 
-    protected void onLevelLoad() {}
+    public abstract void onLevelLoad();
     // --------------------------- END OWN IMPLEMENTATION ------------------------
 
     /**
@@ -73,7 +74,7 @@ public class MainController extends ScreenAdapter {
         hud = new HUDController(hudBatch, hudCamera);
         if (Constants.USE_DUMMY_GENERATOR) generator = new DummyGenerator();
         else generator = new LevelG();
-        levelAPI = new LevelAPI(batch, painter, generator);
+        levelAPI = new LevelAPI(batch, painter, generator, this);
         setup();
     }
 

--- a/code/core/src/demo/MyController.java
+++ b/code/core/src/demo/MyController.java
@@ -30,4 +30,7 @@ public class MyController extends MainController {
     protected void endFrame() {
         camera.setFocusPoint(p);
     }
+
+    @Override
+    public void onLevelLoad() {}
 }

--- a/code/core/src/level/IOnLevelLoader.java
+++ b/code/core/src/level/IOnLevelLoader.java
@@ -1,0 +1,5 @@
+package level;
+
+public interface IOnLevelLoader {
+    public void onLevelLoad();
+}

--- a/code/core/src/level/LevelAPI.java
+++ b/code/core/src/level/LevelAPI.java
@@ -12,15 +12,19 @@ public class LevelAPI {
     private SpriteBatch batch;
     private Painter painter;
     private IGenerator gen;
+    private IOnLevelLoader onLevelLoader;
 
-    public LevelAPI(SpriteBatch batch, Painter painter, IGenerator gen) {
+    public LevelAPI(
+            SpriteBatch batch, Painter painter, IGenerator gen, IOnLevelLoader onLevelLoader) {
         this.gen = gen;
         this.batch = batch;
         this.painter = painter;
+        this.onLevelLoader = onLevelLoader;
     }
 
     public void loadLevel() {
         currentLevel = gen.getLevel();
+        onLevelLoader.onLevelLoad();
         // currentLevel = createDummyLevel();
     }
 


### PR DESCRIPTION
Fixes #108 + `MainController` ist jetzt `abstract`. 

Das Interface `IOnLevelLoader` gibt die Methode `onLevelLoad` vor. Der `MainController` implementiert das Interface und übergibt sich selbst an die `LevelAPI` welche dann die Methode `IOnLevelLoader#onLevelLoad` benutzen kann. 

